### PR TITLE
Allow simpler constructor from functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,29 @@ julia> results(obs, "Error")
 
 ```
 
+As a simplified syntax, you can just pass the functions themselves:
+```julia
+obs = Observer([err_from_π, iteration])
+```
+in which case the results can be accessed as follows:
+```julia
+results(obs, err_from_π) # Or: results(obs, "err_from_π")
+results(obs, iteration) # Or: results(obs, "iteration")
+```
+Note that Julia's internal representation of the function name will be stored in the
+Observer and used to query the results, so searching for results using the String representation
+will not follow aliasing:
+```julia
+const err_from_π_2 = err_from_π
+obs = Observer([err_from_π_2, iteration])
+results(obs, err_from_π)
+results(obs, "err_from_π")
+results(obs, err_from_π_2)
+results(obs, "err_from_π_2") # ERROR: KeyError: key "err_from_π_2" not found
+```
+In addition, for anonymous functions the string name will be a symbol generated internally
+by Julia.
+
 You can save and load Observers with packages like JLD2 (here we use the FileIO interface for JLD2):
 ```julia
 # save the results dictionary as a JLD


### PR DESCRIPTION
This allows using a simpler syntax suggested in #4 where only the functions need to be passed:
```julia
using Observers

# Series for π/4
f(k) = (-1)^(k+1)/(2k-1)

function my_iterative_function(niter; observer!, observe_step)
  π_approx = 0.0
  for n in 1:niter
    π_approx += f(n)
    if iszero(n % observe_step)
      update!(observer!; π_approx = 4π_approx, iteration = n)
    end
  end
  return 4π_approx
end

# Measure the relative error from π at each iteration
err_from_π(; π_approx) = abs(π - π_approx) / π

# Record which iteration we are at
iteration(; iteration) = iteration
obs = Observer([err_from_π, iteration])

niter = 10000
π_approx = my_iterative_function(niter; observer! = obs, observe_step = 1000)

# All of these work:
results(obs, err_from_π)
results(obs, "err_from_π")
results(obs, iteration)
results(obs, "iteration")
```

Closes #4.