### PR TITLE
Change Observer behavior to not include nothing in results

### DIFF
--- a/src/Observers.jl
+++ b/src/Observers.jl
@@ -118,6 +118,9 @@ function update!(obs::Observer, args...; kwargs...)
 end
 
 function update!(obs::Observer, f::Function, k, result)
+
+  isnothing(result) && return # do not include `nothing` in results
+
   if result isa eltype(obs[k].results) && !isempty(obs[k].results)
     update!(f, obs[k].results, result)
   elseif isempty(obs[k].results)


### PR DESCRIPTION
This PR changes the behavior of the Observer to not store the return value of a function if the value is `nothing`. We could consider letting the user configure this value, though `nothing` is a natural choice since it is what a blank `return` statement returns, for example. If a user needs to put a missing value in place then the `missing` singleton is available for that purpose.
