### PR TITLE
Rewrite the `Observer` type as a wrapper around a `DataFrame`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,5 +3,11 @@ uuid = "338f10d5-c7f1-4033-a7d1-f9dec39bcaa0"
 authors = ["Giacomo Torlai <gttorlai@amazon.com>", "Matthew Fishman <mfishman@flatironinstitute.org>"]
 version = "0.0.8"
 
+[deps]
+Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
+ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
+DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+
 [compat]
 julia = "1.4"

--- a/src/Observers.jl
+++ b/src/Observers.jl
@@ -1,21 +1,86 @@
 module Observers
 
-export Observer, results, empty_results!, empty_results, update!
+# TODO: Deprecate `results`, `empty_results!`, `empty_results`.
+# export Observer, results, empty_results!, empty_results, update!
+export Observer, update!
 
-const FunctionAndResults = NamedTuple{(:f,:results),Tuple{Union{Nothing,Function},Any}}
+# TODO: Delete.
+# const FunctionAndResults = NamedTuple{(:f,:results),Tuple{Union{Nothing,Function},Any}}
 
-struct Observer <: AbstractDict{String,FunctionAndResults}
-  data::Dict{String,FunctionAndResults}
+# TODO: Delete.
+# struct Observer <: AbstractDict{String,FunctionAndResults}
+#   data::Dict{String,FunctionAndResults}
+# end
+
+using Accessors
+using ConstructionBase
+using DataFrames
+using DataAPI
+
+struct Observer{DF<:AbstractDataFrame} <: AbstractDataFrame
+  data::DF
+end
+set_data(observer::Observer, data) = (@set observer.data = data)
+data(observer::Observer) = getfield(observer, :data)
+
+Base.parent(observer::Observer) = data(observer)
+Base.copy(observer::Observer) = set_data(observer, copy(data(observer)))
+Base.getindex(observer::Observer, rowind, colind) = getindex(data(observer), rowind, colind)
+const SliceIndices = Union{Colon,Regex,AbstractVector,All,Between,Cols,InvertedIndex}
+Base.getindex(observer::Observer, rowind, colinds::SliceIndices) = getindex(data(observer), rowind, colinds)
+Base.getindex(observer::Observer, rowind::Integer, colinds::SliceIndices) = getindex(data(observer), rowind, colinds)
+Base.getindex(observer::Observer, rowind::Integer, colinds::Colon) = getindex(data(observer), rowind, colinds)
+Base.setproperty!(observer::Observer, f::Symbol, v) = setproperty!(data(observer), f, v)
+Base.setindex!(observer::Observer, v, rowind, colind) = setindex!(data(observer), v, rowind, colind)
+Base.append!(observer::Observer, arg; kwargs...) = append!(data(observer), arg; kwargs...)
+Base.prepend!(observer::Observer, arg; kwargs...) = prepend!(data(observer), arg; kwargs...)
+Base.empty!(observer::Observer) = set_data(observer, empty!(data(observer)))
+Base.push!(observer::Observer, row; kwargs...) = push!(data(observer), row; kwargs...)
+Base.pushfirst!(observer::Observer, row; kwargs...) = pushfirst!(data(observer), row; kwargs...)
+Base.insert!(observer::Observer, index, row; kwargs...) = insert!(data(observer), index, row; kwargs...)
+
+ConstructionBase.setproperties(observer::Observer, patch::NamedTuple) = Observer(patch.data)
+
+# https://dataframes.juliadata.org/stable/lib/metadata/
+DataAPI.nrow(observer::Observer) = nrow(data(observer))
+# metadata, metadatakeys, metadata!, deletemetadata!, emptymetadata!;
+DataAPI.metadata(observer::Observer, args...; kwargs...) = metadata(data(observer), args...; kwargs...)
+DataAPI.metadatakeys(observer::Observer) = metadatakeys(data(observer))
+DataAPI.metadata!(observer::Observer, args...; kwargs...) = metadata!(data(observer), args...; kwargs...)
+DataAPI.deletemetadata!(observer::Observer, args...; kwargs...) = deletemetadata!(data(observer), args...; kwargs...)
+DataAPI.emptymetadata!(observer::Observer) = emptymetadata!(data(observer))
+# colmetadata, colmetadatakeys, colmetadata!, deletecolmetadata!, emptycolmetadata!.
+DataAPI.colmetadata(observer::Observer, args...; kwargs...) = colmetadata(data(observer), args...; kwargs...)
+DataAPI.colmetadatakeys(observer::Observer, args...) = colmetadatakeys(data(observer), args...)
+DataAPI.colmetadata!(observer::Observer, args...; kwargs...) = colmetadata!(data(observer), args...; kwargs...)
+DataAPI.deletecolmetadata!(observer::Observer, args...; kwargs...) = deletecolmetadata!(data(observer), args...; kwargs...)
+DataAPI.emptycolmetadata!(observer::Observer, args...) = emptycolmetadata!(data(observer), args...)
+
+DataFrames.index(observer::Observer) = DataFrames.index(data(observer))
+DataFrames.manipulate(observer::Observer, args; kwargs...) = DataFrames.manipulate(data(observer), args; kwargs...)
+DataFrames._try_select_no_copy(observer::Observer, arg) = DataFrames._try_select_no_copy(data(observer), arg)
+DataFrames.SubDataFrame(observer::Observer, args...) = SubDataFrame(data(observer), args...)
+
+Observer() = Observer(DataFrame())
+
+get_function(observer::Observer, name) = colmetadata(observer, name, "function")
+# Default to `style=:note`, so the metadata gets preserved through
+# verious `DataFrame` operations.
+function set_function!(observer::Observer, name, f; style=:note)
+  if name ∉ names(observer)
+    observer[!, name] = []
+  end
+  colmetadata!(observer, name, "function", f; style)
+  return observer
 end
 
-function Observer(key_function_pairs::Vector{<:Pair})
-  keys = first.(key_function_pairs)
-  functions = last.(key_function_pairs)
-  d = Dict{eltype(keys),FunctionAndResults}()
-  for (k, v) in zip(keys, functions)
-    d[k] = (f = v, results = Any[])
+function Observer(name_function_pairs::Vector{<:Pair})
+  name_function_dict = Dict(name_function_pairs)
+  observer = Observer(DataFrame([name => [] for name in keys(name_function_dict)]))
+  for name in keys(name_function_dict)
+    set_function!(observer, name, name_function_dict[name])
   end
-  return Observer(d)
+  return observer
 end
 
 function Observer(functions::Vector{<:Function})
@@ -30,115 +95,49 @@ function Observer(functions::Function...)
   return Observer([functions...])
 end
 
-struct MissingMethod end
-
-Observer() = Observer(Dict{String,FunctionAndResults}())
-
-Base.length(obs::Observer) = length(obs.data)
-Base.iterate(obs::Observer, args...) = iterate(obs.data, args...)
-
-Base.getindex(obs::Observer, n) = obs.data[string(n)]
-Base.get(obs::Observer, n, x) = get(obs.data, n, x)
-
-Base.setindex!(obs::Observer, observable::Union{Nothing,Function}, obsname) = 
-  Base.setindex!(obs.data, (f = observable, results = Any[]), obsname)
-
-Base.setindex!(obs::Observer, measurements::NamedTuple, obsname) = 
-  Base.setindex!(obs.data, measurements, obsname)
-
-Base.setindex!(obs::Observer, measurements::Tuple{Union{Nothing,Function},Vector{Any}}, obsname) = 
-  Base.setindex!(obs.data, (f = first(measurements), results = last(measurements)), obsname)
-
-Base.copy(observer::Observer) = Observer(copy(observer.data))
-
-Base.empty!(observer::Observer) = empty!(observer.data)
-
-function empty_results!(observer::Observer, k)
-  empty!(results(observer, k))
-  return observer
-end
-
-function empty_results!(observer::Observer)
-  for k in keys(observer)
-    empty_results!(observer, k)
+# TODO: Rewrite as a function `remove_unused_kwargs` that doesn't execute the function.
+function call_and_ignore_unused_kwargs(f::Function, args...; kwargs...)
+  # collect the types of each positional argument being passed into the observer
+  args_types = typeof.(args)
+  # loop over the sequences of possible positional arguments
+  for i in 0:length(args_types)
+    tlist = args_types[1:i]
+    # if a function with argument matching tlist exists:
+    if hasmethod(f, tlist)
+      # check the kwargs of the method
+      kwargs_list = Base.kwarg_decl(which(f, tlist))
+      # remove the input kwargs from the kwargs of the existing method
+      filter!(x -> !(length(string(x)) ≥ 4 && string(x)[end-2:end] == "..."), kwargs_list)
+      # execute the function
+      return f(args[1:i]...; (kwargs_list .=> [kwargs[κ] for κ in kwargs_list])...)
+    end
   end
-  return observer
+  return error("No method found")
 end
 
-empty_results(observer::Observer, args...) = empty_results!(copy(observer), args...)
-
-results(observer::Observer, obsname) = 
-  observer[obsname].results
-
-function set_results!(observer::Observer, results, obsname)
-  observer[obsname] = (f=observer[obsname].f, results=results)
-  return observer
+# Evaluate the function at the column with name `name`
+function call_function(observer::Observer, name, args...; ignore_unused_kwargs=true, kwargs...)
+  f = get_function(observer, name)
+  if ignore_unused_kwargs
+    return call_and_ignore_unused_kwargs(f, args...; kwargs...)
+  end
+  return f(args...; kwargs...)
 end
 
-functions_and_results(obs::Observer) = 
-  obs.data
-
-results(observer::Observer) =
-  Dict([obsname => last(observer[obsname]) for obsname in keys(observer)])
+# Evaluate the function at each column to compute a new row
+function call_functions(observer::Observer, args...; kwargs...)
+  return Dict([name => call_function(observer, name, args...; kwargs...) for name in names(observer)])
+end
 
 """
     update!(obs::Observer, args...; kwargs...)
 
 Update the observer by executing the functions in it.
 """
-function update!(obs::Observer, args...; kwargs...)
-  # loop over the functions
-  for (k, v) in obs
-    obs_k = obs[k]
-    # if a function is defined
-    if !isnothing(obs_k.f)
-      # collect the types of each positional argument being passed into the observer
-      args_types = typeof.(args)
-      # initialize the result to catch a method not being found
-      result = MissingMethod() 
-      # loop over the sequences of possible positional arguments
-      for i in 0:length(args_types)
-        tlist = args_types[1:i]
-        # if a function with argument matching tlist exists:
-        if hasmethod(obs_k.f, tlist)
-          # check the kwargs of such function
-          kwargs_list = Base.kwarg_decl(which(obs_k.f, tlist))
-          # remove the kwargs... from the kwargs
-          filter!(x -> !(length(string(x)) ≥ 4 && string(x)[end-2:end] == "..."), kwargs_list)
-          # execute the function
-          result = obs_k.f(args[1:i]...; (kwargs_list .=> [kwargs[κ] for κ in kwargs_list])...)
-          break
-        end
-      end
-      result isa MissingMethod && error("No method found")
-      update!(obs, obs_k.f, k, result)
-    end
-  end
-  return obs
+function update!(observer::Observer, args...; kwargs...)
+  # TODO: Narrow or expand the element type of each column as needed.
+  push!(observer, call_functions(observer, args...; kwargs...))
+  return observer
 end
-
-function update!(obs::Observer, f::Function, k, result)
-
-  isnothing(result) && return # do not include `nothing` in results
-
-  if result isa eltype(obs[k].results) && !isempty(obs[k].results)
-    update!(f, obs[k].results, result)
-  elseif isempty(obs[k].results)
-    # This sets the type of the results to the type
-    # of the initial results.
-    set_results!(obs, [result], k)
-  else
-    # If the type of the result doesn't fit into the current
-    # results storage, convert the results.
-    T = promote_type(typeof(result), eltype(obs[k].results))
-    obs_k_results = convert(Vector{T}, obs[k].results)
-    update!(f, obs_k_results, result)
-    set_results!(obs, obs_k_results, k)
-  end
-end
-
-# Allows external users to customize updating the results for
-# a given function, for example by emptying them.
-update!(f::Function, results, result) = push!(results, result)
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,11 @@
-using Observers
 using DataFrames
-using Test
 using JLD2
+using Observers
+using SplitApplyCombine
+using Statistics
+using TableMetadataTools
+using TableOperations
+using Test
 
 @testset "Observer" begin
   # Series for π/4
@@ -26,33 +30,33 @@ using JLD2
 
   obs = Observer(["Error" => err_from_π, "Iteration" => iteration])
   
-  @test length(obs) == 2
-  @test results(obs, "Error") == []
-  @test results(obs, "Iteration") == []
+  @test ncol(obs) == 2
+  @test obs.Error == []
+  @test obs.Iteration == []
   
   niter = 10000
   observe_step = 1000
   π_approx = my_iterative_function(niter; observer! = obs, observe_step = observe_step)
   
-  for res in obs
-    @test length(last(last(res))) == niter ÷ observe_step
+  for res in eachcol(obs)
+    @test length(res) == niter ÷ observe_step
   end
   
-  save("outputdata.jld2", results(obs)) 
-  obs_load = load("outputdata.jld2")
+  jldsave("outputdata.jld2"; obs)
+  obs_load = load("outputdata.jld2", "obs")
   
-  for (k,v) in obs_load
-    @test v ≈ last(obs[k])
+  for j in 1:nrow(obs_load)
+    @test obs_load[j, :] == obs[j, :]
   end
   
   obs = Observer(["Error" => err_from_π, "Iteration" => iteration])
-  obs["nofunction"] = nothing
+  Observers.set_function!(obs, "nofunction", Returns(missing))
   
   niter = 10000
   observe_step = 1000
   π_approx = my_iterative_function(niter; observer! = obs, observe_step = observe_step)
   
-  @test results(obs,"nofunction") == []
+  @test isequal(obs[!, "nofunction"], fill(missing, niter ÷ observe_step))
   
   #
   # List syntax
@@ -60,16 +64,16 @@ using JLD2
 
   obs = Observer("Error" => err_from_π, "Iteration" => iteration)
   
-  @test length(obs) == 2
-  @test results(obs, "Error") == []
-  @test results(obs, "Iteration") == []
+  @test ncol(obs) == 2
+  @test obs[!, "Error"] == []
+  @test obs[!, "Iteration"] == []
   
   niter = 10000
   observe_step = 1000
   π_approx = my_iterative_function(niter; observer! = obs, observe_step = observe_step)
   
-  for res in obs
-    @test length(last(last(res))) == niter ÷ observe_step
+  for res in eachcol(obs)
+    @test length(res) == niter ÷ observe_step
   end
 
   #
@@ -78,18 +82,18 @@ using JLD2
 
   obs = Observer(err_from_π, iteration)
   
-  @test length(obs) == 2
-  @test results(obs, err_from_π) == []
-  @test results(obs, "err_from_π") == []
-  @test results(obs, iteration) == []
-  @test results(obs, "iteration") == []
+  @test ncol(obs) == 2
+  @test_broken obs[!, err_from_π] == []
+  @test obs[!, "err_from_π"] == []
+  @test_broken obs[!, iteration] == []
+  @test obs[!, "iteration"] == []
   
   niter = 10000
   observe_step = 1000
   π_approx = my_iterative_function(niter; observer! = obs, observe_step = observe_step)
   
-  for res in obs
-    @test length(last(last(res))) == niter ÷ observe_step
+  for res in eachcol(obs)
+    @test length(res) == niter ÷ observe_step
   end
 
   f1(x::Int) = x^2
@@ -113,11 +117,11 @@ using JLD2
   
   my_other_iterative_function(; observer! = obs)
   
-  @test results(obs,"f1")[1] ≈ 4.0
-  @test results(obs,"f2")[1] ≈ 2.0 + 2*√2
-  @test results(obs,"f3")[1] ≈ 2.0 + 4*√2 
-  @test results(obs,"f4")[1] ≈ 16.0
-  @test results(obs,"f5")[1] ≈ 19.0
+  @test obs[!, "f1"][1] ≈ 4.0
+  @test obs[!, "f2"][1] ≈ 2.0 + 2*√2
+  @test obs[!, "f3"][1] ≈ 2.0 + 4*√2 
+  @test obs[!, "f4"][1] ≈ 16.0
+  @test obs[!, "f5"][1] ≈ 19.0
 end
 
 @testset "Observer constructed from functions" begin
@@ -142,34 +146,36 @@ end
   iteration(; iteration, kwargs...) = iteration
   obs = Observer([err_from_π, iteration])
   
-  @test length(obs) == 2
-  @test results(obs, "err_from_π") == []
-  @test results(obs, "iteration") == []
+  @test ncol(obs) == 2
+  @test obs[!, "err_from_π"] == []
+  @test obs[!, "iteration"] == []
   
   niter = 10000
   observe_step = 1000
   π_approx = my_iterative_function(niter; observer! = obs, observe_step = observe_step)
   
-  @test length(results(obs, "err_from_π")) == niter ÷ observe_step
-  @test length(results(obs, "iteration")) == niter ÷ observe_step
-  @test length(results(obs, err_from_π)) == niter ÷ observe_step
-  @test length(results(obs, iteration)) == niter ÷ observe_step
+  @test length(obs[!, "err_from_π"]) == niter ÷ observe_step
+  @test length(obs[!, "iteration"]) == niter ÷ observe_step
+  @test_broken length(results(obs, err_from_π)) == niter ÷ observe_step
+  @test_broken length(results(obs, iteration)) == niter ÷ observe_step
   f1 = err_from_π
   f2 = iteration
-  @test length(results(obs, f1)) == niter ÷ observe_step
-  @test length(results(obs, f2)) == niter ÷ observe_step
-  @test_throws KeyError results(obs, "f1")
-  @test_throws KeyError results(obs, "f2")
+  @test length(obs[!, string(f1)]) == niter ÷ observe_step
+  @test length(obs[!, string(f2)]) == niter ÷ observe_step
+  @test_broken length(obs[!, f1]) == niter ÷ observe_step
+  @test_broken length(obs[!, f2]) == niter ÷ observe_step
+  @test_throws ArgumentError obs[!, "f1"]
+  @test_throws ArgumentError obs[!, "f2"]
 end
 
 @testset "save only last value" begin
   f(x::Int, y::Float64) = x + y
   g(x::Int) = x
   
-  function Observers.update!(::typeof(g), results, result)
-    empty!(results)
-    push!(results, result)
-  end
+  # function Observers.update!(::typeof(g), results, result)
+  #   empty!(results)
+  #   push!(results, result)
+  # end
   
   function my_yet_another_iterative_function(niter::Int; observer!)
     for k in 1:niter
@@ -183,8 +189,8 @@ end
   
   my_yet_another_iterative_function(100; observer! = obs)
   
-  @test length( results(obs,"g")) == 1
-  @test length( results(obs,"f")) == 100
+  @test length(obs[!, "g"]) == 100
+  @test length(obs[!, "f"]) == 100
 end  
 
 @testset "empty" begin
@@ -200,11 +206,11 @@ end
   @test obs0 == obs1
   iterative(10; observer! = obs1)
   @test obs1 ≠ obs0
-  empty_results!(obs1)
+  empty!(obs1)
   @test obs1 == obs0
 
   iterative(10; observer! = obs1)
-  obs1 = empty_results(obs0)
+  obs1 = empty!(copy(obs0))
   @test obs1 == obs0
 end
 
@@ -222,19 +228,17 @@ end
 
   obs = Observer(["f" => f, "g" => g])
   iterative_function(100; observer! = obs)
-  res = results(obs)
-  @test length(res["f"]) == 100
-  @test length(res["g"]) == 100
-  @test res["f"] isa Vector{Float64}
-  @test res["g"] isa Vector{ComplexF64}
+  @test length(obs.f) == 100
+  @test length(obs.g) == 100
+  @test obs.f isa Vector
+  @test obs.g isa Vector
 
   obs = Observer(["f" => f, "g" => g])
   iterative_function(10; observer! = obs)
-  res = results(obs)
-  @test length(res["f"]) == 10
-  @test length(res["g"]) == 10
-  @test res["f"] isa Vector{Float64}
-  @test res["g"] isa Vector{Int}
+  @test length(obs.f) == 10
+  @test length(obs.g) == 10
+  @test obs.f isa Vector
+  @test obs.g isa Vector
 end
 
 @testset "Function Returning nothing" begin
@@ -254,6 +258,7 @@ end
     if iteration%2 == 0
       return total
     end
+    return missing
   end
   
   obs = Observer(["RunningTotal" => running_total, 
@@ -263,15 +268,16 @@ end
   niter = 100
   total = sumints(niter; observer! = obs)
 
-  eo = results(obs)["EveryOther"]
-  rt = results(obs)["RunningTotal"]
+  eo = obs.EveryOther
+  rt = obs.RunningTotal
 
   # Test that `nothing` does not appear in eo:
-  @test findfirst(isnothing,eo) == nothing
+  @test findfirst(isnothing, eo) == nothing
 
   # Test that eo contains every other value of rt:
-  @test length(eo) == div(length(rt),2)
-  @test eo == rt[2:2:niter]
+  @test sum(!ismissing, eo) == div(length(rt), 2)
+  @test eo[2:2:niter] == rt[2:2:niter]
+  @test all(ismissing, eo[1:2:niter])
 
 end
 
@@ -287,12 +293,207 @@ end
   end
   obs = Observer(["f" => f, "g" => g])
   iterative_function(100; observer! = obs)
-  res = results(obs)
-  df = DataFrame(results(obs))
-  @test df.f == res["f"]
-  @test df.g == res["g"]
+  df = DataFrame(obs)
+  @test df.f == obs.f
+  @test df.g == obs.g
   @test length(df.f) == 100
   @test length(df.g) == 100
-  @test df.f isa Vector{Float64}
-  @test df.g isa Vector{ComplexF64}
+  @test df.f isa Vector
+  @test df.g isa Vector
+end
+
+@testset "DataFrames functionality" begin
+  o = Observer(DataFrame((a=[1, 2], b=[3, 4])))
+
+  # https://tables.juliadata.org/stable/#Implementing-the-Interface-(i.e.-becoming-a-Tables.jl-source)
+  # https://github.com/JuliaData/TableOperations.jl
+  # TODO: Turn into tests.
+  @test Tables.rows(o) isa DataFrames.DataFrameRows
+  @test Tables.columns(o) isa DataFrames.DataFrameColumns
+  @test Tables.columnnames(o) == [:a, :b]
+  row = Tables.rows(o)[1]
+  @test [Tables.getcolumn(row, col) for col in Tables.columnnames(row)] == [1, 3]
+  row = Tables.rows(o)[2]
+  @test [Tables.getcolumn(row, col) for col in Tables.columnnames(row)] == [2, 4]
+  col = Tables.columnnames(Tables.columns(o))[1]
+  @test Tables.getcolumn(Tables.columns(o), col) == [1, 2]
+  col = Tables.columnnames(Tables.columns(o))[2]
+  @test Tables.getcolumn(Tables.columns(o), col) == [3, 4]
+  @test Tables.subset(o, 2:2) isa DataFrame
+  @test Tables.subset(o, 2:2) == DataFrame((; a=[2], b=[4]))
+  @test Tables.istable(typeof(o))
+  @test Tables.rowaccess(typeof(o))
+  @test Tables.rows(o) isa DataFrames.DataFrameRows
+  @test Tables.columnaccess(typeof(o))
+  @test Tables.columns(o) isa DataFrames.DataFrameColumns
+  @test Tables.schema(o) isa Tables.Schema
+  @test Tables.materializer(typeof(o)) <: DataFrame
+
+  # TableOperations.jl
+  @test Tables.columntable(TableOperations.select(:a)(o)) == (; a=[1, 2])
+  @test DataFrame(TableOperations.select(:a)(o)) == DataFrame((; a=[1, 2]))
+  @test DataFrame(TableOperations.transform(a=x->Symbol(x))(o)) == DataFrame((; a=[Symbol(1), Symbol(2)], b=[3, 4]))
+  @test DataFrame(TableOperations.filter(x->Tables.getcolumn(x, :b) > 3)(o)) == DataFrame((; a=[2], b=[4]))
+  @test DataFrame(TableOperations.map(x->(a=Tables.getcolumn(x, :b) * 2, b=Tables.getcolumn(x, :a) * 2))(o)) == DataFrame((; a=[6, 8], b=[2, 4]))
+
+  @test copy(o) == o
+  @test names(o) == ["a", "b"]
+  @test propertynames(o) == [:a, :b]
+  @test eltype.(eachcol(o)) == [Int, Int]
+  @test nrow(o) == 2
+  @test ncol(o) == 2
+  @test size(o) == (2, 2)
+  @test size(o, 1) == 2
+  @test size(o, 2) == 2
+  @test o.a == [1, 2]
+  @test o.b == [3, 4]
+  oc = copy(o)
+  oc.a = ["x", "y"]
+  @test oc.a == ["x", "y"]
+  @test o.b == [3, 4]
+  oc = copy(o)
+  append!(oc, DataFrame((a=[10, 20], b=[30, 40])))
+  @test oc.a == [1, 2, 10, 20]
+  @test oc.b == [3, 4, 30, 40]
+  oc = copy(o)
+  prepend!(oc, DataFrame((a=[15, 25], b=[35, 45])))
+  @test oc.a == [15, 25, 1, 2]
+  @test oc.b == [35, 45, 3, 4]
+  @test empty(o) == Observer(DataFrame((a=Int[], b=Int[])))
+  @test isempty(empty(o))
+  @test empty!(copy(o)) == Observer(DataFrame((a=Int[], b=Int[])))
+  @test describe(o) isa DataFrame
+  @test describe(o; cols=1:1) isa DataFrame
+  io = IOBuffer()
+  show(io, o; allcols=true)
+  @test String(take!(io)) isa String
+
+  # Statistics.jl
+  @test mean(o.a) == 1.5
+  oc = mapcols(id -> id .^ 2, o)
+  @test oc.a == [1, 4]
+  @test oc.b == [9, 16]
+  @test first(o, 1) isa DataFrame
+  @test nrow(first(o, 1)) == 1
+  @test first(o) isa DataFrameRow
+  @test last(o, 1) isa DataFrame
+  @test nrow(last(o, 1)) == 1
+  @test last(o) isa DataFrameRow
+  oc = sort(o; rev=true)
+  @test oc isa DataFrame
+  @test oc.a == [2, 1]
+  @test oc.b == [4, 3]
+  oc = subset(o, :a => x -> x .> 1)
+  @test oc isa DataFrame
+  @test oc.a == [2]
+  @test oc.b == [4]
+  @test o[1, [:a]] isa DataFrameRow
+  @test size(o[1, [:a]]) == (1,)
+  @test o[1, [:a]].a == 1
+  @test o[1:1, [:a]] isa DataFrame
+  @test size(o[1:1, [:a]]) == (1, 1)
+  @test o[1:1, [:a]].a == [1]
+  oc = copy(o)
+  oc[:, [:a]] = [4 5]'
+  @test oc.a == [4, 5]
+  @test oc.b == [3, 4]
+  oc[!, [:a, :b]] = [8 9; 10 11]
+  @test oc.a == [8, 10]
+  @test oc.b == [9, 11]
+  oc[:, :a] = [12, 13]
+  @test oc.a == [12, 13]
+  oc[1, :a] = 45
+  @test oc.a == [45, 13]
+
+  # https://dataframes.juliadata.org/stable/man/split_apply_combine/
+  # SplitApplyCombine.jl
+  oc = copy(o)
+  pushfirst!(oc, Dict(:a => 10, :b => 3))
+  oc_grouped = groupby(oc, :b)
+  @test oc_grouped isa GroupedDataFrame
+  @test length(oc_grouped) == 2
+  @test keys(oc_grouped) == [(; b=3), (; b=4)]
+  @test oc_grouped[(; b=3)].a == [10, 1]
+  @test oc_grouped[(; b=3)].b == [3, 3]
+  @test oc_grouped[(; b=4)].a == [2]
+  @test oc_grouped[(; b=4)].b == [4]
+
+  # https://dataframes.juliadata.org/stable/lib/metadata/
+  # TODO: Design an `observer_function[!]` or `get_function`/`set_function!`
+  # interface similar to `labels[!]` and `notes[!]` from `TableMetadataTools`.
+  oc = copy(o)
+  colmetadata!(oc, :a, "function", sin; style=:note)
+  colmetadata!(oc, :b, "function", cos; style=:note)
+  @test colmetadata(oc, :a, "function") == sin
+  @test colmetadata(oc, :b, "function") == cos
+  oc = Observer(sort(oc; rev=true))
+  @test oc isa Observer
+  @test colmetadata(oc, :a, "function") == sin
+  @test colmetadata(oc, :b, "function") == cos
+
+  # TableMetadataTools.jl
+  # https://github.com/JuliaData/TableMetadataTools.jl
+  # https://github.com/JuliaData/TableMetadataTools.jl/blob/main/docs/demo.ipynb
+  @test label(o, :a) == "a"
+  @test label(o, :b) == "b"
+  @test labels(o) == ["a", "b"]
+  @test findlabels(contains("a"), o) == [:a => "a"]
+  @test note(o) == ""
+  @test note(o, :a) == ""
+  @test note(o, :b) == ""
+  oc = copy(o)
+  oc = caption!(oc, "o_caption")
+  @test caption(oc) == "o_caption"
+  oc = copy(o)
+  oc = note!(oc, "o_note")
+  @test note(oc) == "o_note"
+  oc = copy(o)
+  metadata!(oc, "x1", "y1")
+  metadata!(oc, "x2", "y2")
+  @test metadata(oc, "x1") == "y1"
+  @test metadata(oc, "x2") == "y2"
+  label!(oc, :a, "al1")
+  note!(oc, :a, "a1")
+  note!(oc, :a, "a2"; append=true)
+  @test label(oc, :a) == "al1"
+  @test note(oc, :a) == "a1\na2"
+  @test meta2toml(oc) isa String
+  @test !isempty(metadata(oc))
+  @test !isempty(colmetadata(oc))
+  emptymetadata!(oc)
+  @test isempty(metadata(oc))
+  @test !isempty(colmetadata(oc))
+  emptycolmetadata!(oc)
+  @test isempty(metadata(oc))
+  @test isempty(colmetadata(oc))
+  metadata!(oc, "a", "a1")
+  metadata!(oc, "b", "b1")
+  @test metadata(oc) == Dict("a" => "a1", "b" => "b1")
+  deletemetadata!(oc, "a")
+  @test metadata(oc) == Dict("b" => "b1")
+  colmetadata!(oc, :a, "aa", "aa1"; style=:note)
+  colmetadata!(oc, :a, "ab", "ab1"; style=:note)
+  colmetadata!(oc, :b, "ba", "ba1"; style=:note)
+  colmetadata!(oc, :b, "bb", "bb1"; style=:note)
+  @test colmetadata(oc, :a) == Dict("aa" => "aa1", "ab" => "ab1")
+  @test colmetadata(oc, :b) == Dict("ba" => "ba1", "bb" => "bb1")
+  deletecolmetadata!(oc, :a, "aa")
+  @test colmetadata(oc, :a) == Dict("ab" => "ab1")
+  oc = oc[:, [:b]]
+  @test ncol(oc) == 1
+  @test colmetadata(oc, :b) == Dict("ba" => "ba1", "bb" => "bb1")
+
+  # TODO: Extract more tests from these sources:
+  # https://dataframes.juliadata.org/stable/man/basics/#Getting-and-Setting-Data-in-a-Data-Frame
+  # https://dataframes.juliadata.org/stable/man/getting_started/#The-DataFrame-Type
+  # https://dataframes.juliadata.org/stable/man/working_with_dataframes/#Taking-a-Subset
+  # https://dataframes.juliadata.org/stable/man/working_with_dataframes/#Selecting-and-transforming-columns
+  # https://dataframes.juliadata.org/stable/man/working_with_dataframes/#Handling-of-Columns-Stored-in-a-DataFrame
+  # https://dataframes.juliadata.org/stable/man/working_with_dataframes/#Replacing-Data
+  # https://dataframes.juliadata.org/stable/man/importing_and_exporting/#CSV-Files
+  # https://dataframes.juliadata.org/stable/man/joins/
+  # https://dataframes.juliadata.org/stable/man/split_apply_combine/#Examples-of-the-split-apply-combine-operations
+  # https://dataframes.juliadata.org/stable/man/reshaping_and_pivoting/#Reshaping-and-Pivoting-Data
+  # https://dataframes.juliadata.org/stable/man/sorting/#Sorting
+  # https://dataframes.juliadata.org/stable/man/missing/#Missing-Data
 end


### PR DESCRIPTION
Rewrite the `Observer` type as a wrapper around a `DataFrame` from [DataFrames.jl](https://dataframes.juliadata.org/stable/) and a subtype of `AbstractDataFrames`. This makes the implementation simpler, the interface clearer (which basically just follows the interface of `DataFrames.jl` but with a few extra functions), and makes it so that Observers can support many more operations now (most of the ones `DataFrame` objects support, from what I've tested).