### PR TITLE
Improve and export column function accessors

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,58 @@ julia> obs.Error
 ```
 
 
+## Accessing and modifying functions
+
+
+
+You can access and modify functions of an Observer with `get_function`, `set_function!`, and `insert_function!`:
+
+```julia
+julia> get_function(obs, "Iteration") == iter
+true
+
+julia> get_function(obs, "Error") == err
+true
+
+julia> set_function!(obs, "Error" => sin);
+
+julia> get_function(obs, "Error") == sin
+true
+
+julia> insert_function!(obs, "New column" => cos);
+
+julia> get_function(obs, "New column") == cos
+true
+
+julia> obs
+10×3 Observer
+ Row │ Iteration  Error        New column
+     │ Int64      Float64      Missing
+─────┼────────────────────────────────────
+   1 │      1000  0.00031831      missing
+   2 │      2000  0.000159155     missing
+   3 │      3000  0.000106103     missing
+   4 │      4000  7.95775e-5      missing
+   5 │      5000  6.3662e-5       missing
+   6 │      6000  5.30516e-5      missing
+   7 │      7000  4.54728e-5      missing
+   8 │      8000  3.97887e-5      missing
+   9 │      9000  3.53678e-5      missing
+  10 │     10000  3.1831e-5       missing
+```
+
+
+`set_function!` just updates the function of an existing column but doesn't create new columns,
+while `insert_function!` creates a new column and sets the function of that new column
+but won't update an existing column.
+For example, these will both throw errors:
+```julia
+set_function!(obs, "New column 2", cos)
+insert_function!(obs, "Error", cos)
+```
+
+
+
 Alternatively, if you define the `Observer` with column names to begin with,
 then you can get the results using the function names:
 

--- a/examples/README.jl
+++ b/examples/README.jl
@@ -145,6 +145,27 @@ rename!(obs, ["Iteration", "Error"])
 obs.Iteration
 obs.Error
 
+#' ## Accessing and modifying functions
+
+#' You can access and modify functions of an Observer with `get_function`, `set_function!`, and `insert_function!`:
+#+ term=true
+get_function(obs, "Iteration") == iter
+get_function(obs, "Error") == err
+set_function!(obs, "Error" => sin);
+get_function(obs, "Error") == sin
+insert_function!(obs, "New column" => cos);
+get_function(obs, "New column") == cos
+obs
+
+#' `set_function!` just updates the function of an existing column but doesn't create new columns,
+#' while `insert_function!` creates a new column and sets the function of that new column
+#' but won't update an existing column.
+#' For example, these will both throw errors:
+#' ```julia
+#' set_function!(obs, "New column 2", cos)
+#' insert_function!(obs, "Error", cos)
+#' ```
+
 #' Alternatively, if you define the `Observer` with column names to begin with,
 #' then you can get the results using the function names:
 #+ term=true

--- a/src/Observers.jl
+++ b/src/Observers.jl
@@ -1,6 +1,6 @@
 module Observers
 
-export Observer, update!
+export Observer, update!, get_function, set_function!, insert_function!
 
 using Accessors
 using ConstructionBase

--- a/src/observer.jl
+++ b/src/observer.jl
@@ -29,7 +29,9 @@ end
 # Errors if the column already exists.
 function insert_function!(observer::Observer, name, f::Function; set_function!_kwargs...)
   if name ∈ names(observer)
-    error("Trying to insert a new function with `insert_function!`, but a column with name `$(name)` already exists. Use `set_function!` if you want to replace the function of an existing column, or use a different name than the existing column names `$(names(observer))`.")
+    error(
+      "Trying to insert a new function with `insert_function!`, but a column with name `$(name)` already exists. Use `set_function!` if you want to replace the function of an existing column, or use a different name than the existing column names `$(names(observer))`.",
+    )
   end
   # Append a new column and then set the function.
   observer[!, name] = isempty(observer) ? Union{}[] : fill(missing, nrow(observer))

--- a/src/observer.jl
+++ b/src/observer.jl
@@ -39,7 +39,9 @@ function insert_function!(observer::Observer, name, f::Function; set_function!_k
   return observer
 end
 
-function insert_function!(observer::Observer, name_function::Pair{<:Any,<:Function}; kwargs...)
+function insert_function!(
+  observer::Observer, name_function::Pair{<:Any,<:Function}; kwargs...
+)
   return insert_function!(observer, first(name_function), last(name_function); kwargs...)
 end
 

--- a/src/observer.jl
+++ b/src/observer.jl
@@ -11,22 +11,38 @@ get_function(observer::Observer, name) = colmetadata(observer, name, "function")
 # Set the function of a column of the Observer.
 # Default to `style=:note`, so the metadata gets preserved through
 # verious `DataFrame` operations.
-function set_function!(observer::Observer, name, f; style=:note)
+function set_function!(observer::Observer, name, f::Function; style=:note)
   colmetadata!(observer, name, "function", f; style)
   return observer
+end
+
+function set_function!(observer::Observer, name_function::Pair{<:Any,<:Function}; kwargs...)
+  return set_function!(observer, first(name_function), last(name_function); kwargs...)
+end
+
+function set_function!(observer::Observer, f::Function; kwargs...)
+  return set_function!(observer, string(f), f; kwargs...)
 end
 
 # Insert a new function into the Observer by appending a new column
 # filled with `missing`.
 # Errors if the column already exists.
-function insert_function!(observer::Observer, name, f; set_function!_kwargs...)
+function insert_function!(observer::Observer, name, f::Function; set_function!_kwargs...)
   if name ∈ names(observer)
-    error("Trying to insert a new function, but column with name $(name) already exists.")
+    error("Trying to insert a new function with `insert_function!`, but a column with name `$(name)` already exists. Use `set_function!` if you want to replace the function of an existing column, or use a different name than the existing column names `$(names(observer))`.")
   end
   # Append a new column and then set the function.
-  observer[!, name] = fill(missing, nrow(observer))
+  observer[!, name] = isempty(observer) ? Union{}[] : fill(missing, nrow(observer))
   set_function!(observer, name, f; set_function!_kwargs...)
   return observer
+end
+
+function insert_function!(observer::Observer, name_function::Pair{<:Any,<:Function}; kwargs...)
+  return insert_function!(observer, first(name_function), last(name_function); kwargs...)
+end
+
+function insert_function!(observer::Observer, f::Function; kwargs...)
+  return insert_function!(observer, string(f), f; kwargs...)
 end
 
 # Constructors

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -78,8 +78,6 @@ returns_test() = "test"
     observe_step = 1000
     π_approx = my_iterative_function(niter; (observer!)=obs, observe_step=observe_step)
 
-    @show obs
-
     @test nrow(obs) == niter ÷ observe_step
     @test all(ismissing, obs.nofunction)
     @test obs.Error .^ 2 == obs.Error²
@@ -95,8 +93,6 @@ returns_test() = "test"
 
     obs2 = copy(obs)
     π_approx = my_iterative_function(niter; (observer!)=obs2, observe_step=observe_step)
-
-    @show obs2
 
     @test nrow(obs2) == 2nrow(obs)
     first_half = 1:(niter ÷ observe_step)


### PR DESCRIPTION
This exports `get_function`, `set_function!`, and `insert_function!`. It also makes them a bit more flexible in what inputs the setter functions accept (i.e. you can now also pass name-function pairs or just functions), and handles the element type promotion of new columns made by `insert_function!` a bit better.

@emstoudenmire