### PR TITLE
In `update!`, skip rows with all `missing` or `nothing` values by default

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,12 +5,14 @@ version = "0.1.1"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 
 [compat]
 Accessors = "0.1.28"
+Compat = "4.6.1"
 ConstructionBase = "1.5.1"
 DataAPI = "1.14.0"
 DataFrames = "1.5.0"

--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@
 
 
 
-The Observers.jl package provides functionalities to record and track metrics of interest during the iterative evaluation
-of a given function. It may be used to monitor convergence of optimization algorithms, to measure revelant observables in
-in numerical simulations (e.g. condensed matter physics, quantum simulation, quantum chemistry etc).
+The Observers.jl package provides functionalities to record and track metrics of interest
+during the iterative evaluation of a given function. It may be used to monitor convergence
+of optimization algorithms, measure revelant observables in numerical simulations,
+print useful information from an iterative method, etc.
 
 
 
@@ -21,7 +22,8 @@ Observers.jl v0.1 has been released, which preserves the same basic constructor
 and `update!` interface but a new design of the `Observer` type, which now
 has the interface and functionality of a `DataFrame` from
 [DataFrames.jl](https://dataframes.juliadata.org/stable/). See the rest of
-this [README](https://github.com/GTorlai/Observers.jl#readme), the [examples/](https://github.com/GTorlai/Observers.jl/tree/main/examples)
+this [README](https://github.com/GTorlai/Observers.jl#readme), the
+[examples/](https://github.com/GTorlai/Observers.jl/tree/main/examples)
 and [test/](https://github.com/GTorlai/Observers.jl/tree/main/test) directories, and
 the [DataFrames.jl documentation](https://dataframes.juliadata.org/stable/)
 to learn about how to use the new `Observer` type.

--- a/examples/README.jl
+++ b/examples/README.jl
@@ -3,9 +3,10 @@
 
 #' # Observers.jl
 
-#' The Observers.jl package provides functionalities to record and track metrics of interest during the iterative evaluation
-#' of a given function. It may be used to monitor convergence of optimization algorithms, to measure revelant observables in
-#' in numerical simulations (e.g. condensed matter physics, quantum simulation, quantum chemistry etc).
+#' The Observers.jl package provides functionalities to record and track metrics of interest
+#' during the iterative evaluation of a given function. It may be used to monitor convergence
+#' of optimization algorithms, measure revelant observables in numerical simulations,
+#' print useful information from an iterative method, etc.
 
 #' ## News
 
@@ -13,7 +14,8 @@
 #' and `update!` interface but a new design of the `Observer` type, which now
 #' has the interface and functionality of a `DataFrame` from
 #' [DataFrames.jl](https://dataframes.juliadata.org/stable/). See the rest of
-#' this [README](https://github.com/GTorlai/Observers.jl#readme), the [examples/](https://github.com/GTorlai/Observers.jl/tree/main/examples)
+#' this [README](https://github.com/GTorlai/Observers.jl#readme), the
+#' [examples/](https://github.com/GTorlai/Observers.jl/tree/main/examples)
 #' and [test/](https://github.com/GTorlai/Observers.jl/tree/main/test) directories, and
 #' the [DataFrames.jl documentation](https://dataframes.juliadata.org/stable/)
 #' to learn about how to use the new `Observer` type.

--- a/src/Observers.jl
+++ b/src/Observers.jl
@@ -1,6 +1,8 @@
 module Observers
 
 export Observer, update!, get_function, set_function!, insert_function!
+# Deprecated
+export results
 
 using Accessors
 using ConstructionBase
@@ -11,5 +13,6 @@ include("method_utils.jl")
 include("observer.jl")
 include("dataframes_interface.jl")
 include("update.jl")
+include("deprecated.jl")
 
 end # module

--- a/src/Observers.jl
+++ b/src/Observers.jl
@@ -5,6 +5,7 @@ export Observer, update!, get_function, set_function!, insert_function!
 export results
 
 using Accessors
+using Compat
 using ConstructionBase
 using DataFrames
 using DataAPI

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,0 +1,3 @@
+function results(observer::Observer, args...)
+  return error("""The syntax `results(observer::Observer, "name")` and `results(observer::Observer)["name"]` for accessing results from an Observer are deprecated. You can access the results of an Observer directly with the DataFrames.jl syntax `observer.name` or `observer[!, "name"]`. As of Observers v0.1, Observer objects have the functionality and interface of DataFrame objects. See the [DataFrames documentation](https://dataframes.juliadata.org/stable/) for more details.""")
+end

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,3 +1,5 @@
 function results(observer::Observer, args...)
-  return error("""The syntax `results(observer::Observer, "name")` and `results(observer::Observer)["name"]` for accessing results from an Observer are deprecated. You can access the results of an Observer directly with the DataFrames.jl syntax `observer.name` or `observer[!, "name"]`. As of Observers v0.1, Observer objects have the functionality and interface of DataFrame objects. See the [DataFrames documentation](https://dataframes.juliadata.org/stable/) for more details.""")
+  return error(
+    """The syntax `results(observer::Observer, "name")` and `results(observer::Observer)["name"]` for accessing results from an Observer are deprecated. You can access the results of an Observer directly with the DataFrames.jl syntax `observer.name` or `observer[!, "name"]`. As of Observers v0.1, Observer objects have the functionality and interface of DataFrame objects. See the [DataFrames documentation](https://dataframes.juliadata.org/stable/) for more details.""",
+  )
 end

--- a/src/update.jl
+++ b/src/update.jl
@@ -7,7 +7,7 @@ function call_function(
   call_function_kwargs = (;
     default_call_function_kwargs(call_function)..., call_function_kwargs...
   )
-  (; ignore_unsupported_trailing_args, ignore_unsupported_kwargs) = call_function_kwargs
+  @compat (; ignore_unsupported_trailing_args, ignore_unsupported_kwargs) = call_function_kwargs
   f = get_function(observer, name)
   if ignore_unsupported_trailing_args
     args = remove_unsupported_trailing_args(f, args)

--- a/src/update.jl
+++ b/src/update.jl
@@ -7,7 +7,8 @@ function call_function(
   call_function_kwargs = (;
     default_call_function_kwargs(call_function)..., call_function_kwargs...
   )
-  @compat (; ignore_unsupported_trailing_args, ignore_unsupported_kwargs) = call_function_kwargs
+  @compat (; ignore_unsupported_trailing_args, ignore_unsupported_kwargs) =
+    call_function_kwargs
   f = get_function(observer, name)
   if ignore_unsupported_trailing_args
     args = remove_unsupported_trailing_args(f, args)

--- a/src/update.jl
+++ b/src/update.jl
@@ -1,15 +1,18 @@
+function default_call_function_kwargs(::typeof(call_function))
+  return (;
+    ignore_unsupported_trailing_args=false,
+    ignore_unsupported_kwargs=false,
+  )
+end
+
 # Evaluate the function at the column with name `name`.
 # Optiononally ignores any unsupported trailing arguments and
 # unssuported keyword arguments that are pass to the function.
 function call_function(
   observer::Observer, name, args...; call_function_kwargs=(;), kwargs...
 )
-  ignore_unsupported_trailing_args = get(
-    call_function_kwargs, :ignore_unsupported_trailing_args, false
-  )
-  ignore_unsupported_kwargs = get(
-    call_function_kwargs, :ignore_unsupported_trailing_args, false
-  )
+  call_function_kwargs = (; default_call_function_kwargs(call_function)..., call_function_kwargs...)
+  (; ignore_unsupported_trailing_args, ignore_unsupported_kwargs) = call_function_kwargs
   f = get_function(observer, name)
   if ignore_unsupported_trailing_args
     args = remove_unsupported_trailing_args(f, args)
@@ -32,24 +35,52 @@ function call_functions(observer::Observer, args...; call_function_kwargs=(;), k
   )
 end
 
+default_push!_kwargs(::typeof(update!)) = (; promote=true, skip_missing_rows=true, skip_nothing_rows=true)
+function default_call_function_kwargs(::typeof(update!))
+  return (; ignore_unsupported_trailing_args=true,
+    ignore_unsupported_kwargs=true
+  )
+end
+
 """
-    update!(obs::Observer, args...; promote=true, kwargs...)
+    update!(
+      obs::Observer,
+      args...;
+      push!_kwargs=(; promote=true, skip_missing_rows=true, skip_nothing_rows=true),
+      kwargs...,
+    )
 
-Update the observer by executing the functions in it.
+Update the observer by executing the functions stored on each column,
+passing the arguments `args...` and keyword arguments `kwargs...`
+to each function.
 
-Promotes the column data if needed by default. That can be disabled
-by setting `promote=false`.
+By default, `update!` promotes the type of the column data if needed,
+if new data can't be converted to the current data type of the column.
+That can be disabled by setting `push!_kwargs=(; promote=false)`.
+
+Also, by default, rows that have all `missing` data or all `nothing`
+data don't get pushed into the `observer`. That can be disabled by setting
+`push!_kwargs=(; skip_missing_rows=false)` and/or `push!_kwargs=(; skip_nothing_rows=false)`.
 """
 function update!(
   observer::Observer,
   args...;
-  call_function_kwargs=(;
-    ignore_unsupported_trailing_args=true, ignore_unsupported_kwargs=true
-  ),
-  push!_kwargs=(; promote=true),
+  push!_kwargs=(;),
+  call_function_kwargs=(;),
   kwargs...,
 )
+  push!_kwargs = (; default_push!_kwargs(update!)..., push!_kwargs...)
+  skip_missing_rows = push!_kwargs.skip_missing_rows
+  skip_nothing_rows = push!_kwargs.skip_nothing_rows
+  push!_kwargs = Base.structdiff(push!_kwargs, (; skip_missing_rows, skip_nothing_rows))
+  call_function_kwargs = (; default_call_function_kwargs(update!)..., call_function_kwargs...)
   function_outputs = call_functions(observer, args...; call_function_kwargs, kwargs...)
+  if skip_missing_rows && all(ismissing, values(function_outputs))
+    return observer
+  end
+  if skip_nothing_rows && all(isnothing, values(function_outputs))
+    return observer
+  end
   push!(observer, function_outputs; push!_kwargs...)
   return observer
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -66,6 +66,10 @@ returns_test() = "test"
     error_sqr = (; π_approx) -> err_from_π(; π_approx)^2
     insert_function!(obs, "Error²", error_sqr)
 
+    # Check deprecation
+    @test_throws ErrorException results(obs)
+    @test_throws ErrorException results(obs, "Error")
+
     @test names(obs) == ["Error", "Iteration", "nofunction", "Error²"]
     @test get_function(obs, "Error") == err_from_π
     @test get_function(obs, "nofunction") == nofunction

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -179,6 +179,24 @@ returns_test() = "test"
     @test obs[!, "f5"][1] ≈ 19.0
   end
 
+  @testset "Observer skip missing or nothing" begin
+    obs = Observer("x" => Returns(missing), "y" => Returns(missing))
+    @test isempty(obs)
+    update!(obs)
+    @test isempty(obs)
+    update!(obs; push!_kwargs=(; skip_all_missing=false))
+    @test nrow(obs) == 1
+    @test all(ismissing, obs[1, :])
+
+    obs = Observer("x" => Returns(nothing), "y" => Returns(nothing))
+    @test isempty(obs)
+    update!(obs)
+    @test isempty(obs)
+    update!(obs; push!_kwargs=(; skip_all_nothing=false))
+    @test nrow(obs) == 1
+    @test all(isnothing, obs[1, :])
+  end
+
   @testset "Observer constructed from functions" begin
     # Series for π/4
     f(k) = (-1)^(k + 1) / (2k - 1)


### PR DESCRIPTION
In `update!`, skip rows with all `missing` or `nothing` values by default. This is similar to the previous `Observer` behavior, and let's you more easily skip saving data at certain iterations.

@emstoudenmire I noticed this was a feature that had been dropped by the new redesign.