### PR TITLE
Define default observer() function to fix ambiguity error

### DIFF
--- a/src/dataframe/observer.jl
+++ b/src/dataframe/observer.jl
@@ -1,6 +1,8 @@
 # Convenient constructors of DataFrames with functions as column metadata,
 # called an "observer".
 
+observer() = DataFrame()
+
 # In general, fall back to `DataFrame` constructors.
 observer(args...; kwargs...) = DataFrame(args...; kwargs...)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,12 @@ nofunction() = missing
 returns_test() = "test"
 
 @testset "Observers" begin
+  @testset "Constructors" begin
+    # Test that we can default construct
+    obs = observer()
+    @test size(obs) == (0, 0)
+  end
+
   @testset "Examples" begin
     example_files = ["example1.jl", "README.jl"]
     for example_file in example_files


### PR DESCRIPTION
Calling `observer()` was throwing an ambiguous function error, so this PR explicitly defines the `observer()` function in the case of no arguments passed.
