### PR TITLE
Add remove_function! method

### DIFF
--- a/src/Observers.jl
+++ b/src/Observers.jl
@@ -1,6 +1,6 @@
 module Observers
 
-export observer, update!, get_function, set_function!, insert_function!
+export observer, update!, get_function, set_function!, insert_function!, remove_function!
 # Deprecated
 export results
 

--- a/src/abstractdataframe/column_functions.jl
+++ b/src/abstractdataframe/column_functions.jl
@@ -44,6 +44,10 @@ function insert_function!(df::AbstractDataFrame, f::Function; kwargs...)
   return insert_function!(df, string(f), f; kwargs...)
 end
 
+function remove_function!(df::AbstractDataFrame, f::Function)
+  return select!(df, Not(string(f)))
+end
+
 # Evaluate the function at the column with name `name`.
 # Optiononally ignores any unsupported trailing arguments and
 # unssuported keyword arguments that are pass to the function.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -344,7 +344,6 @@ returns_test() = "test"
   end
 
   @testset "Insert and remove function" begin
-
     function my_iterative_function(niter; observer!, observe_step)
       π_approx = 0.0
       for n in 1:niter
@@ -359,18 +358,16 @@ returns_test() = "test"
     obs = observer("Error" => err_from_π)
     @test names(obs) == ["Error"]
 
-    insert_function!(obs,iteration)
-    @test names(obs) == ["Error","iteration"]
+    insert_function!(obs, iteration)
+    @test names(obs) == ["Error", "iteration"]
 
     niter = 10000
     observe_step = 1000
     π_approx = my_iterative_function(niter; (observer!)=obs, observe_step=observe_step)
 
-    @test size(obs) == (10,2)
-    remove_function!(obs,iteration)
+    @test size(obs) == (10, 2)
+    remove_function!(obs, iteration)
     @test names(obs) == ["Error"]
-    @test size(obs) == (10,1)
-
+    @test size(obs) == (10, 1)
   end
-
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -342,4 +342,35 @@ returns_test() = "test"
     @test eo[2:2:niter] == rt[2:2:niter]
     @test all(ismissing, eo[1:2:niter])
   end
+
+  @testset "Insert and remove function" begin
+
+    function my_iterative_function(niter; observer!, observe_step)
+      π_approx = 0.0
+      for n in 1:niter
+        π_approx += f(n)
+        if iszero(n % observe_step)
+          update!(observer!; π_approx=4π_approx, iteration=n)
+        end
+      end
+      return 4π_approx
+    end
+
+    obs = observer("Error" => err_from_π)
+    @test names(obs) == ["Error"]
+
+    insert_function!(obs,iteration)
+    @test names(obs) == ["Error","iteration"]
+
+    niter = 10000
+    observe_step = 1000
+    π_approx = my_iterative_function(niter; (observer!)=obs, observe_step=observe_step)
+
+    @test size(obs) == (10,2)
+    remove_function!(obs,iteration)
+    @test names(obs) == ["Error"]
+    @test size(obs) == (10,1)
+
+  end
+
 end


### PR DESCRIPTION
Adds a method named `remove_function!` which does the opposite of `insert_function!`.

The justification for adding this function is that while the DataFrames interface makes it possible to remove a function from an observer, by doing
```julia
select!(obs, Not(:function))
```
using the above code has some drawbacks:
- the code above not very intuitive and not as self documenting as it could be
  (e.g. compare it to just calling `insert_function!(obs, function)`)
- doing `using DataFrames` inside of ITensorNetworks led to some issues. 
  DataFrames exports functions such as `Not` and `order` which conflict with
  definitions from ITensorNetworks or other packages that ITensorNetworks depends
  on. Being able to remove a function through the Observers package interface
  would avoid needing to do `using DataFrames` inside of ITensorNetworks.
